### PR TITLE
addons/dispatch: fix argocd version, update values for argo-cd metrics

### DIFF
--- a/addons/dispatch/0.5.x/dispatch-4.yaml
+++ b/addons/dispatch/0.5.x/dispatch-4.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: dispatch
+  labels:
+    kubeaddons.mesosphere.io/name: dispatch
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.3-2"
+    appversion.kubeaddons.mesosphere.io/dispatch: "0.5.3"
+    endpoint.kubeaddons.mesosphere.io/dispatch: /dispatch/tekton/
+    docs.kubeaddons.mesosphere.io/dispatch: "https://beta-dispatch.d2iq.com/"
+    stage.kubeaddons.mesosphere.io/dispatch: Beta
+    appversion.kubeaddons.mesosphere.io/argo-cd: "1.4.2"
+    endpoint.kubeaddons.mesosphere.io/argo-cd: /dispatch/argo-cd
+    docs.kubeaddons.mesosphere.io/argo-cd: "https://argoproj.github.io/argo-cd/user-guide/"
+    stage.kubeaddons.mesosphere.io/argo-cd: Beta
+    values.chart.helm.kubeaddons.mesosphere.io/dispatch: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/dispatch/values.yaml"
+spec:
+  namespace: dispatch
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: gcp
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: prometheus
+  chartReference:
+    chart: dispatch
+    repo: https://mesosphere.github.io/dispatch
+    version: 0.5.3
+    values: |
+      ---
+      argo-cd:
+        controller:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
+        server:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
+        repoServer:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
+
+      global:
+        prometheus:
+          enabled: true
+          release: prometheus-kubeaddons
+        grafana:
+          enabled: true
+          namespace: kubeaddons


### PR DESCRIPTION
Diff against `dispatch-3.yaml`:
```
@@ -7,12 +7,12 @@ metadata:
     kubeaddons.mesosphere.io/name: dispatch
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.3-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.3-2"
     appversion.kubeaddons.mesosphere.io/dispatch: "0.5.3"
     endpoint.kubeaddons.mesosphere.io/dispatch: /dispatch/tekton/
     docs.kubeaddons.mesosphere.io/dispatch: "https://beta-dispatch.d2iq.com/"
     stage.kubeaddons.mesosphere.io/dispatch: Beta
-    appversion.kubeaddons.mesosphere.io/argo-cd: "1.2.0"
+    appversion.kubeaddons.mesosphere.io/argo-cd: "1.4.2"
     endpoint.kubeaddons.mesosphere.io/argo-cd: /dispatch/argo-cd
     docs.kubeaddons.mesosphere.io/argo-cd: "https://argoproj.github.io/argo-cd/user-guide/"
     stage.kubeaddons.mesosphere.io/argo-cd: Beta
@@ -42,9 +42,24 @@ spec:
     values: |
       ---
       argo-cd:
-        prometheus:
-          enabled: true
-          release: prometheus-kubeaddons
+        controller:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
+        server:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
+        repoServer:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              additionalLabels:
+                release: prometheus-kubeaddons
 
       global:
         prometheus:
```