### PR TITLE
Override Kommander UI full name.

### DIFF
--- a/addons/dispatch/1.3.x/dispatch-4.yaml
+++ b/addons/dispatch/1.3.x/dispatch-4.yaml
@@ -79,6 +79,8 @@ spec:
             serviceMonitor:
               additionalLabels:
                 release: prometheus-kubeaddons
+      kommander-ui:
+        fullnameOverride: dispatch-kommander-ui
       tekton:
         webhook:
           replicas: 3 # tekton webhook


### PR DESCRIPTION
This would make sure that the kommander chart creates `dispatch-kommander-ui-sa` service account.