### PR TITLE
Fix D2IQ-73940: standalone minio upgrade failure.

### DIFF
--- a/addons/dispatch/1.4.x/dispatch-2.yaml
+++ b/addons/dispatch/1.4.x/dispatch-2.yaml
@@ -99,6 +99,8 @@ spec:
           enabled: true
           namespace: kubeaddons
       minio:
+        DeploymentUpdate:
+          type: Recreate
         persistence:
           size: "50Gi" # minio
       buildkit:


### PR DESCRIPTION
[D2IQ-73940](https://jira.d2iq.com/browse/D2IQ-73940)

Manually tested against a AWS konvoy cluster with the following commands:
```
 helm upgrade --install dispatch dispatch/dispatch --version 1.3.1 --namespace dispatch --create-namespace --debug --wait --timeout=300s
 helm upgrade --install dispatch dispatch/dispatch --version 1.4.0-rc1 --namespace dispatch --create-namespace --debug --wait --timeout=300 --set minio.DeploymentUpdate.type=Recreate
```

Without `minio.DeploymentUpdate.type=Recreate` the upgrade would fail.