### PR TITLE
chore: bump kommander-ui image to match

### DIFF
--- a/addons/dispatch/1.4.x/dispatch-9.yaml
+++ b/addons/dispatch/1.4.x/dispatch-9.yaml
@@ -85,6 +85,9 @@ spec:
       dispatch:
         image: "mesosphere/dispatch:1.4.5"
         testImage: "mesosphere/dispatch-helm-test:1.4.5"
+      kommander-ui:
+        image:
+          defaultTag: 6.98.0
       tekton:
         controller:
           images:


### PR DESCRIPTION
Based the PR on https://github.com/mesosphere/kubeaddons-dispatch/commit/db44be033d7e8c9e309004200d46ba6d76954ed4

As discussed in our standup, to short circuit for the release, bumping the version here. 